### PR TITLE
Update gtag-opt-in to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-wiki",
-  "version": "0.1.44",
+  "version": "0.1.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7869,9 +7869,9 @@
       "optional": true
     },
     "gtag-opt-in": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gtag-opt-in/-/gtag-opt-in-2.0.0.tgz",
-      "integrity": "sha512-tYYEmWRWoQJsLxoDnRdY8eDHb3TEHaLNOo0DoC/5cNUXvN4uTpOa3PgKdmF9pL0zxt43Ju+XqsGxG6GdtuQNhw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gtag-opt-in/-/gtag-opt-in-3.0.0.tgz",
+      "integrity": "sha512-3y3GSrUnTxiaOkrb8aXHYVDyuoX1HSTifP3b2h5kQAHIztLGOgEiCffJmGyodHZWJ7M4IkLOahdsQwd6cwZpQQ=="
     },
     "gzip-size": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "axios": "^0.21.1",
     "axios-cache-adapter": "^2.7.3",
     "fuse.js": "^6.4.6",
-    "gtag-opt-in": "^2.0.0",
+    "gtag-opt-in": "^3.0.0",
     "localforage": "^1.9.0",
     "moment": "^2.29.1",
     "node-sass": "^5.0.0",


### PR DESCRIPTION
v3 includes fixes for lots of security issues included in old versions of dev-dependencies